### PR TITLE
Use Standard_LRS for storage account

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -496,7 +496,7 @@ module avmStorageAccount 'br/public:avm/res/storage/storage-account:0.20.0' = {
   params: {
     name: 'st${replace(solutionPrefix, '-', '')}'
     location: resourceGroupLocation
-    //skuName: 'Standard_GRS'
+    skuName: 'Standard_LRS'
     //kind: 'StorageV2'
     managedIdentities: { systemAssigned: true }
     minimumTlsVersion: 'TLS1_2'


### PR DESCRIPTION
## Summary
- set storage account sku to Standard_LRS

## Testing
- `pytest` *(fails: Defining 'pytest_plugins' in a non-top-level conftest is no longer supported; AttributeError: 'NoneType' object has no attribute 'endswith')*

------
https://chatgpt.com/codex/tasks/task_e_68acddb52e80832e84735c5062879253